### PR TITLE
feat: Add MakeCode screenshot replacement with Dutch versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,19 +17,23 @@ Review default standards in @C:\Users\alain\CascadeProjects\Coderdojo\guides
 
 ```
 src/
-├── cli.py              # Command-line interface
-├── pipeline.py         # Orchestrates the full workflow
-├── scraper.py          # Playwright-based page fetcher
-├── extractor.py        # BeautifulSoup content extraction
-├── enhancer.py         # Upscayl image processing
-├── translator.py       # Dutch translation
-├── generator.py        # Markdown generation
+├── cli.py                  # Command-line interface
+├── pipeline.py             # Orchestrates the full workflow
+├── scraper.py              # Playwright-based page fetcher
+├── extractor.py            # BeautifulSoup content extraction
+├── makecode_detector.py    # Detects MakeCode links and code images
+├── makecode_capture.py     # Captures Dutch MakeCode screenshots
+├── makecode_replacer.py    # Replaces English screenshots with Dutch
+├── downloader.py           # Downloads images
+├── enhancer.py             # Upscayl image processing
+├── translator.py           # Dutch translation
+├── generator.py            # Markdown generation
 └── sources/
-    ├── base.py         # Base source adapter
-    └── elecfreaks.py   # Elecfreaks-specific extraction rules
-tests/                  # Test files
-output/                 # Generated guides (gitignored)
-cache/                  # Downloaded pages cache (gitignored)
+    ├── base.py             # Base source adapter
+    └── elecfreaks.py       # Elecfreaks-specific extraction rules
+tests/                      # Test files
+output/                     # Generated guides (gitignored)
+cache/                      # Downloaded pages cache (gitignored)
 ```
 
 ## Common Commands
@@ -44,6 +48,9 @@ playwright install chromium       # Install browser for scraping
 ```bash
 # Generate single guide
 python -m src.cli generate --url "<URL>" --output ./output
+
+# Generate guide without MakeCode replacement
+python -m src.cli generate --url "<URL>" --output ./output --no-makecode
 
 # Generate all guides from index
 python -m src.cli batch --index "<URL>" --output ./output
@@ -65,10 +72,13 @@ uv run ruff format src/
 
 ## Configuration
 
-Key paths (configurable via environment or config.toml):
+Key paths and settings (configurable via environment variables):
 - **Upscayl:** `C:\Program Files\Upscayl\Upscayl.exe`
 - **Output:** `./output`
 - **Cache:** `./cache`
+- **MakeCode Language:** `MAKECODE_LANGUAGE=nl` (default: Dutch)
+- **MakeCode Timeout:** `MAKECODE_TIMEOUT=30000` (ms, default: 30s)
+- **MakeCode Replacement:** `MAKECODE_REPLACE_ENABLED=True` (default: enabled)
 
 ## Code Conventions
 
@@ -93,6 +103,11 @@ Key paths (configurable via environment or config.toml):
 - 76 tutorials in Nezha Inventor's Kit
 - Upscayl has limited CLI support - may need workarounds
 - Rate limiting important to avoid IP blocking
+- MakeCode screenshots: Automatically replaces English code block images with Dutch versions
+  - Detects MakeCode links in "Reference" sections
+  - Matches code images to MakeCode project URLs
+  - Captures Dutch screenshots using Playwright
+  - Gracefully falls back to original images on failure
 
 ## External Resources
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -49,6 +49,13 @@ class Settings(BaseSettings):
     TRANSLATION_SOURCE: str = Field(default="en", description="Source language")
     TRANSLATION_TARGET: str = Field(default="nl", description="Target language (Dutch)")
 
+    # MakeCode settings
+    MAKECODE_LANGUAGE: str = Field(default="nl", description="Language for MakeCode screenshots")
+    MAKECODE_TIMEOUT: int = Field(default=30000, description="MakeCode page load timeout in ms")
+    MAKECODE_REPLACE_ENABLED: bool = Field(
+        default=True, description="Enable MakeCode screenshot replacement"
+    )
+
 
 # Singleton pattern for settings
 _settings: Settings | None = None

--- a/src/makecode_capture.py
+++ b/src/makecode_capture.py
@@ -1,0 +1,167 @@
+"""MakeCode screenshot capture for Dutch code block images."""
+
+import asyncio
+import inspect
+import logging
+from pathlib import Path
+
+from playwright.async_api import Browser, Page
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+from src.core.config import get_settings
+
+settings = get_settings()
+logger = logging.getLogger(__name__)
+
+
+async def capture_makecode_screenshot(
+    url: str,
+    output_path: Path,
+    browser: Browser,
+    language: str = "nl",
+    timeout: int = 30000,
+) -> bool:
+    """Capture a screenshot of MakeCode editor in specified language.
+
+    Args:
+        url: MakeCode project URL (e.g., https://makecode.microbit.org/_iscUF8CzzYMd)
+        output_path: Where to save the screenshot.
+        browser: Playwright browser instance (reused from scraper).
+        language: Language code (default: 'nl' for Dutch).
+        timeout: Timeout in milliseconds for page load.
+
+    Returns:
+        True if screenshot captured successfully, False otherwise.
+    """
+    logger.debug(f" * {inspect.currentframe().f_code.co_name} > Capturing: {url}")
+
+    page: Page | None = None
+
+    try:
+        # Create new page
+        page = await browser.new_page()
+        logger.debug("    -> Created new page")
+
+        # Add language parameter to URL
+        url_with_lang = f"{url}?lang={language}" if "?" not in url else f"{url}&lang={language}"
+        logger.debug(f"    -> Loading URL with language: {url_with_lang}")
+
+        # Navigate to URL
+        response = await page.goto(url_with_lang, timeout=timeout)
+
+        if response is None:
+            logger.error("    -> No response received")
+            return False
+
+        if response.status >= 400:
+            logger.error(f"    -> HTTP {response.status}")
+            return False
+
+        # Wait for editor to load
+        logger.debug("    -> Waiting for editor to load")
+
+        # Try multiple selectors for the editor
+        editor_selectors = [
+            "#maineditor",
+            ".monaco-editor",
+            ".blocklyDiv",
+            "#blocksEditor",
+        ]
+
+        editor_loaded = False
+        for selector in editor_selectors:
+            try:
+                await page.wait_for_selector(selector, timeout=timeout, state="visible")
+                logger.debug(f"    -> Editor loaded (selector: {selector})")
+                editor_loaded = True
+                break
+            except PlaywrightTimeoutError:
+                continue
+
+        if not editor_loaded:
+            logger.warning("    -> Editor did not load within timeout")
+            # Continue anyway, might still get a useful screenshot
+
+        # Wait a bit more for blocks to render
+        await asyncio.sleep(2)
+        logger.debug("    -> Waited for blocks to render")
+
+        # Ensure output directory exists
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Take screenshot
+        # Try to screenshot just the editor area first
+        try:
+            editor_element = await page.query_selector("#maineditor")
+            if editor_element:
+                await editor_element.screenshot(path=str(output_path))
+                logger.debug(f"    -> Screenshot saved (element): {output_path}")
+            else:
+                # Fall back to full page screenshot
+                await page.screenshot(path=str(output_path), full_page=True)
+                logger.debug(f"    -> Screenshot saved (full page): {output_path}")
+        except Exception as screenshot_error:
+            logger.warning(f"    -> Element screenshot failed: {screenshot_error}")
+            # Fall back to full page screenshot
+            await page.screenshot(path=str(output_path), full_page=True)
+            logger.debug(f"    -> Screenshot saved (full page fallback): {output_path}")
+
+        return True
+
+    except PlaywrightTimeoutError as e:
+        logger.error(f"    -> Timeout loading MakeCode page: {e}")
+        return False
+
+    except Exception as e:
+        logger.error(f"    -> Failed to capture screenshot: {e}")
+        return False
+
+    finally:
+        if page:
+            await page.close()
+            logger.debug("    -> Page closed")
+
+
+async def capture_multiple_screenshots(
+    url_mapping: dict[int, str],
+    output_dir: Path,
+    browser: Browser,
+    language: str = "nl",
+) -> dict[int, Path]:
+    """Capture multiple MakeCode screenshots.
+
+    Args:
+        url_mapping: Dict mapping image index to MakeCode URL.
+        output_dir: Base output directory for screenshots.
+        browser: Playwright browser instance.
+        language: Language code for screenshots.
+
+    Returns:
+        Dict mapping image index to saved screenshot path (only successful captures).
+    """
+    logger.debug(
+        f" * {inspect.currentframe().f_code.co_name} > Capturing {len(url_mapping)} screenshots"
+    )
+
+    results = {}
+
+    for img_idx, makecode_url in url_mapping.items():
+        # Generate output path
+        filename = f"makecode_{img_idx:03d}.png"
+        output_path = output_dir / filename
+
+        # Capture screenshot
+        success = await capture_makecode_screenshot(makecode_url, output_path, browser, language)
+
+        if success:
+            results[img_idx] = output_path
+            logger.debug(f"    -> Successfully captured image {img_idx}")
+        else:
+            logger.warning(f"    -> Failed to capture image {img_idx}")
+
+        # Rate limiting between captures
+        if settings.RATE_LIMIT_SECONDS > 0:
+            await asyncio.sleep(settings.RATE_LIMIT_SECONDS)
+
+    logger.debug(f"    -> Successfully captured {len(results)}/{len(url_mapping)} screenshots")
+    return results

--- a/src/makecode_detector.py
+++ b/src/makecode_detector.py
@@ -1,0 +1,133 @@
+"""MakeCode image detector for identifying code screenshots and project links."""
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class MakeCodeImageDetector:
+    """Detects MakeCode code screenshots and associated project links."""
+
+    # Pattern for MakeCode project URLs
+    MAKECODE_URL_PATTERN = re.compile(
+        r"https?://makecode\.microbit\.org/_[A-Za-z0-9]+",
+        re.IGNORECASE,
+    )
+
+    # Keywords that suggest an image is a code screenshot
+    CODE_IMAGE_KEYWORDS = [
+        "code",
+        "program",
+        "makecode",
+        "scratch",
+        "blocks",
+        "script",
+    ]
+
+    def find_makecode_links(self, sections: list[dict[str, Any]]) -> list[str]:
+        """Extract MakeCode project URLs from content sections.
+
+        Args:
+            sections: List of section dicts with heading and content.
+
+        Returns:
+            List of MakeCode project URLs found in the content.
+        """
+        logger.debug(f"Searching for MakeCode links in {len(sections)} sections")
+        links = []
+
+        for section in sections:
+            # Check section heading
+            heading = section.get("heading", "")
+            found_in_heading = self.MAKECODE_URL_PATTERN.findall(heading)
+            links.extend(found_in_heading)
+
+            # Check section content (BeautifulSoup Tag objects)
+            content = section.get("content", [])
+            for element in content:
+                # Convert element to string to search for URLs
+                element_str = str(element)
+                found_in_content = self.MAKECODE_URL_PATTERN.findall(element_str)
+                links.extend(found_in_content)
+
+        # Remove duplicates while preserving order
+        unique_links = list(dict.fromkeys(links))
+        logger.debug(f"Found {len(unique_links)} unique MakeCode links")
+        return unique_links
+
+    def _is_code_image(self, image: dict[str, str], index: int) -> bool:
+        """Check if an image is likely a code screenshot.
+
+        Args:
+            image: Image dict with src, alt, title.
+            index: Image index in the list.
+
+        Returns:
+            True if the image appears to be a code screenshot.
+        """
+        # Check alt text and title for code-related keywords
+        alt = image.get("alt", "").lower()
+        title = image.get("title", "").lower()
+        src = image.get("src", "").lower()
+
+        text_to_check = f"{alt} {title} {src}"
+
+        for keyword in self.CODE_IMAGE_KEYWORDS:
+            if keyword in text_to_check:
+                logger.debug(f"Image {index} matched keyword '{keyword}': {alt or title or src}")
+                return True
+
+        return False
+
+    def match_images_to_links(
+        self, images: list[dict[str, str]], links: list[str]
+    ) -> dict[int, str]:
+        """Match code screenshots to their MakeCode project URLs.
+
+        Uses heuristics to pair images with links:
+        1. Code images typically appear before reference links
+        2. Multiple code images map to multiple links in order
+        3. Only images matching code keywords are considered
+
+        Args:
+            images: List of image dicts with src, alt, title.
+            links: List of MakeCode project URLs.
+
+        Returns:
+            Dictionary mapping image index to MakeCode URL.
+        """
+        logger.debug(f"Matching {len(images)} images to {len(links)} MakeCode links")
+
+        if not links:
+            logger.debug("No MakeCode links to match")
+            return {}
+
+        # Find all code images
+        code_images = [
+            (idx, img) for idx, img in enumerate(images) if self._is_code_image(img, idx)
+        ]
+
+        if not code_images:
+            logger.debug("No code images detected")
+            return {}
+
+        logger.debug(f"Found {len(code_images)} code images")
+
+        # Match images to links in order
+        matches = {}
+        for i, (img_idx, _) in enumerate(code_images):
+            if i < len(links):
+                matches[img_idx] = links[i]
+                logger.debug(f"Matched image {img_idx} to link {links[i]}")
+            else:
+                # More code images than links - log warning
+                logger.warning(f"Code image at index {img_idx} has no corresponding MakeCode link")
+
+        if len(links) > len(code_images):
+            logger.warning(
+                f"Found {len(links)} MakeCode links but only {len(code_images)} code images"
+            )
+
+        return matches

--- a/src/makecode_replacer.py
+++ b/src/makecode_replacer.py
@@ -1,0 +1,95 @@
+"""MakeCode screenshot replacement logic."""
+
+import inspect
+import logging
+from pathlib import Path
+
+from playwright.async_api import Browser
+
+from src.core.config import get_settings
+from src.makecode_capture import capture_multiple_screenshots
+from src.makecode_detector import MakeCodeImageDetector
+from src.sources.base import ExtractedContent
+
+settings = get_settings()
+logger = logging.getLogger(__name__)
+
+
+async def replace_makecode_screenshots(
+    content: ExtractedContent,
+    output_dir: Path,
+    browser: Browser,
+    language: str = "nl",
+) -> ExtractedContent:
+    """Replace English MakeCode screenshots with Dutch versions.
+
+    Args:
+        content: Extracted content with images.
+        output_dir: Base output directory.
+        browser: Playwright browser instance.
+        language: Target language for screenshots (default: 'nl').
+
+    Returns:
+        Updated ExtractedContent with Dutch screenshots.
+    """
+    logger.debug(f" * {inspect.currentframe().f_code.co_name} > Processing MakeCode replacements")
+
+    # Step 1: Detect MakeCode links and code images
+    detector = MakeCodeImageDetector()
+
+    makecode_links = detector.find_makecode_links(content.sections)
+    if not makecode_links:
+        logger.debug("    -> No MakeCode links found, skipping replacement")
+        return content
+
+    logger.debug(f"    -> Found {len(makecode_links)} MakeCode links")
+
+    # Step 2: Match images to links
+    image_to_link_map = detector.match_images_to_links(content.images, makecode_links)
+    if not image_to_link_map:
+        logger.debug("    -> No code images matched to links, skipping replacement")
+        return content
+
+    logger.debug(f"    -> Matched {len(image_to_link_map)} images to MakeCode links")
+
+    # Step 3: Capture Dutch screenshots
+    images_dir = output_dir / settings.IMAGE_OUTPUT_DIR
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    captured_screenshots = await capture_multiple_screenshots(
+        image_to_link_map, images_dir, browser, language
+    )
+
+    if not captured_screenshots:
+        logger.warning("    -> No screenshots captured successfully")
+        return content
+
+    logger.debug(f"    -> Captured {len(captured_screenshots)} Dutch screenshots")
+
+    # Step 4: Update image references
+    replaced_count = 0
+    for img_idx, screenshot_path in captured_screenshots.items():
+        if img_idx < len(content.images):
+            # Store original for potential backup/debugging
+            original_src = content.images[img_idx].get("src")
+            logger.debug(f"    -> Replacing image {img_idx}: {original_src}")
+
+            # Update image dict with Dutch screenshot
+            relative_path = str(Path(settings.IMAGE_OUTPUT_DIR) / screenshot_path.name)
+            content.images[img_idx]["local_path"] = relative_path
+            content.images[img_idx]["makecode_url"] = image_to_link_map[img_idx]
+            content.images[img_idx]["replaced_with_dutch"] = True
+
+            # Keep original URL for reference
+            if "src" not in content.images[img_idx].get("_original", {}):
+                content.images[img_idx]["_original_src"] = original_src
+
+            replaced_count += 1
+
+    logger.debug(f"    -> Replaced {replaced_count} images with Dutch versions")
+
+    # Update metadata
+    content.metadata["makecode_replacements"] = replaced_count
+    content.metadata["makecode_links_found"] = len(makecode_links)
+
+    return content

--- a/tests/test_makecode_detector.py
+++ b/tests/test_makecode_detector.py
@@ -1,0 +1,133 @@
+"""Tests for MakeCode image detector."""
+
+from bs4 import BeautifulSoup
+
+from src.makecode_detector import MakeCodeImageDetector
+
+
+def test_find_makecode_links():
+    """Test finding MakeCode links in sections."""
+    detector = MakeCodeImageDetector()
+
+    sections = [
+        {
+            "heading": "Introduction",
+            "content": [
+                BeautifulSoup(
+                    "<p>Some text with a link: "
+                    '<a href="https://makecode.microbit.org/_iscUF8CzzYMd">Project</a></p>',
+                    "html.parser",
+                ).p
+            ],
+        },
+        {
+            "heading": "Reference",
+            "content": [
+                BeautifulSoup(
+                    '<p>Link: <a href="https://makecode.microbit.org/_abc123def456">Project 2</a></p>',
+                    "html.parser",
+                ).p
+            ],
+        },
+    ]
+
+    links = detector.find_makecode_links(sections)
+
+    assert len(links) == 2
+    assert "https://makecode.microbit.org/_iscUF8CzzYMd" in links
+    assert "https://makecode.microbit.org/_abc123def456" in links
+
+
+def test_find_makecode_links_no_duplicates():
+    """Test that duplicate links are removed."""
+    detector = MakeCodeImageDetector()
+
+    sections = [
+        {
+            "heading": "Introduction",
+            "content": [
+                BeautifulSoup(
+                    '<p><a href="https://makecode.microbit.org/_test123">Project</a></p>',
+                    "html.parser",
+                ).p,
+                BeautifulSoup(
+                    '<p><a href="https://makecode.microbit.org/_test123">Same Project</a></p>',
+                    "html.parser",
+                ).p,
+            ],
+        }
+    ]
+
+    links = detector.find_makecode_links(sections)
+
+    assert len(links) == 1
+    assert "https://makecode.microbit.org/_test123" in links
+
+
+def test_is_code_image():
+    """Test code image detection."""
+    detector = MakeCodeImageDetector()
+
+    # Image with "code" in alt text
+    code_image = {"src": "image.png", "alt": "code blocks", "title": ""}
+    assert detector._is_code_image(code_image, 0) is True
+
+    # Image with "makecode" in filename
+    makecode_image = {"src": "makecode_screenshot.png", "alt": "", "title": ""}
+    assert detector._is_code_image(makecode_image, 1) is True
+
+    # Regular image
+    regular_image = {"src": "photo.jpg", "alt": "A photo", "title": ""}
+    assert detector._is_code_image(regular_image, 2) is False
+
+
+def test_match_images_to_links():
+    """Test matching code images to MakeCode links."""
+    detector = MakeCodeImageDetector()
+
+    images = [
+        {"src": "intro.png", "alt": "Introduction", "title": ""},
+        {"src": "code1.png", "alt": "code blocks", "title": ""},
+        {"src": "photo.jpg", "alt": "Photo", "title": ""},
+        {"src": "code2.png", "alt": "program", "title": ""},
+    ]
+
+    links = [
+        "https://makecode.microbit.org/_link1",
+        "https://makecode.microbit.org/_link2",
+    ]
+
+    matches = detector.match_images_to_links(images, links)
+
+    assert len(matches) == 2
+    assert matches[1] == "https://makecode.microbit.org/_link1"  # code1.png
+    assert matches[3] == "https://makecode.microbit.org/_link2"  # code2.png
+
+
+def test_match_images_to_links_no_links():
+    """Test matching when no links are provided."""
+    detector = MakeCodeImageDetector()
+
+    images = [
+        {"src": "code.png", "alt": "code blocks", "title": ""},
+    ]
+
+    matches = detector.match_images_to_links(images, [])
+
+    assert len(matches) == 0
+
+
+def test_match_images_to_links_no_code_images():
+    """Test matching when no code images are found."""
+    detector = MakeCodeImageDetector()
+
+    images = [
+        {"src": "photo1.jpg", "alt": "Photo", "title": ""},
+        {"src": "photo2.jpg", "alt": "Another photo", "title": ""},
+    ]
+
+    links = ["https://makecode.microbit.org/_link1"]
+
+    matches = detector.match_images_to_links(images, links)
+
+    assert len(matches) == 0


### PR DESCRIPTION
Implements automatic replacement of English MakeCode code block screenshots with Dutch versions by capturing screenshots from MakeCode project URLs.

Changes:
- Add makecode_detector.py to detect MakeCode links and match to code images
- Add makecode_capture.py to capture Dutch screenshots using Playwright
- Add makecode_replacer.py to orchestrate the replacement workflow
- Update cli.py to integrate MakeCode replacement into pipeline
- Add --no-makecode flag to optionally disable replacement
- Add MakeCode configuration settings to config.py
- Add tests for MakeCode detection logic
- Update CLAUDE.md with feature documentation

The feature:
- Detects MakeCode project URLs in Reference sections
- Matches code block images to MakeCode URLs using heuristics
- Captures Dutch screenshots by appending ?lang=nl to URLs
- Gracefully falls back to original images on failures
- Non-breaking: can be disabled with --no-makecode flag

Related to issue #3