### PR TITLE
Adapt output structure to keep markdown at root with assets in subfol…

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -113,7 +113,7 @@ async def download_images(content: ExtractedContent, output_dir: Path) -> Extrac
 
     Args:
         content: Extracted content with images to download.
-        output_dir: Base output directory.
+        output_dir: Guide-specific output directory (e.g., output/guide-name).
 
     Returns:
         Updated ExtractedContent with local_path set for downloaded images.
@@ -152,8 +152,9 @@ async def download_images(content: ExtractedContent, output_dir: Path) -> Extrac
                 success = await download_image(url, output_path, client)
 
                 if success:
-                    # Store relative path for markdown
-                    image["local_path"] = str(Path(settings.IMAGE_OUTPUT_DIR) / filename)
+                    # Store relative path for markdown including guide subdirectory
+                    guide_name = output_dir.name
+                    image["local_path"] = str(Path(guide_name) / settings.IMAGE_OUTPUT_DIR / filename)
                 else:
                     logger.warning(f"    -> Failed to download image {idx}: {url}")
 

--- a/src/makecode_replacer.py
+++ b/src/makecode_replacer.py
@@ -68,14 +68,15 @@ async def replace_makecode_screenshots(
 
     # Step 4: Update image references
     replaced_count = 0
+    guide_name = output_dir.name
     for img_idx, screenshot_path in captured_screenshots.items():
         if img_idx < len(content.images):
             # Store original for potential backup/debugging
             original_src = content.images[img_idx].get("src")
             logger.debug(f"    -> Replacing image {img_idx}: {original_src}")
 
-            # Update image dict with Dutch screenshot
-            relative_path = str(Path(settings.IMAGE_OUTPUT_DIR) / screenshot_path.name)
+            # Update image dict with Dutch screenshot (include guide subdirectory)
+            relative_path = str(Path(guide_name) / settings.IMAGE_OUTPUT_DIR / screenshot_path.name)
             content.images[img_idx]["local_path"] = relative_path
             content.images[img_idx]["makecode_url"] = image_to_link_map[img_idx]
             content.images[img_idx]["replaced_with_dutch"] = True

--- a/src/qrcode_processor.py
+++ b/src/qrcode_processor.py
@@ -129,7 +129,7 @@ def process_markdown_links(markdown: str, output_dir: Path) -> tuple[str, list[Q
 
     Args:
         markdown: Markdown content to process.
-        output_dir: Base output directory for the guide.
+        output_dir: Guide-specific output directory (e.g., output/guide-name).
 
     Returns:
         Tuple of:
@@ -138,7 +138,7 @@ def process_markdown_links(markdown: str, output_dir: Path) -> tuple[str, list[Q
 
     Example:
         Input:  "Visit [our site](https://example.com) for more info"
-        Output: "Visit [our site](https://example.com) ![](qrcodes/qr_001.png) for more info"
+        Output: "Visit [our site](https://example.com) ![](guide-name/qrcodes/qr_001.png) for more info"
     """
     if not markdown or not markdown.strip():
         logger.debug(" * process_markdown_links > No content to process")
@@ -164,6 +164,7 @@ def process_markdown_links(markdown: str, output_dir: Path) -> tuple[str, list[Q
     # Process each link
     qr_codes: list[QRCodeInfo] = []
     offset = 0  # Track string modifications
+    guide_name = output_dir.name
 
     for idx, match in enumerate(matches, start=1):
         url = match.group(2)
@@ -186,8 +187,8 @@ def process_markdown_links(markdown: str, output_dir: Path) -> tuple[str, list[Q
         qr_codes.append(qr_info)
 
         # Inject QR code reference inline after the link
-        # Use relative path from output directory with scaling if applicable
-        qr_markdown = f" ![](qrcodes/{filename})"
+        # Use relative path including guide subdirectory
+        qr_markdown = f" ![]({guide_name}/qrcodes/{filename})"
 
         # Apply QR code scaling if not 1.0
         from src.core.config import get_settings
@@ -195,7 +196,7 @@ def process_markdown_links(markdown: str, output_dir: Path) -> tuple[str, list[Q
         if settings.QRCODE_SCALE != 1.0:
             # Calculate new size
             new_size = int(100 * settings.QRCODE_SCALE)  # Base size is 100px
-            qr_markdown = f" ![](qrcodes/{filename}|{new_size})"
+            qr_markdown = f" ![]({guide_name}/qrcodes/{filename}|{new_size})"
 
         # Calculate insertion position (after the closing parenthesis)
         insert_pos = match.end() + offset


### PR DESCRIPTION
…ders

- Markdown files saved at output root (e.g., output/guide1.md)
- Images and QR codes organized in guide-specific subfolders
- Updated all relative paths to include guide name prefix
- Modified: cli.py, downloader.py, makecode_replacer.py, qrcode_processor.py